### PR TITLE
Add norsk-henvisningsstandard-for-rettsvitenskapelige-tekster

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.csl text eol=lf
+*.xml text eol=lf
+*.json text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-*.csl text eol=lf
-*.xml text eol=lf
-*.json text eol=lf

--- a/diffs/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-full-firstnote.diff
+++ b/diffs/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-full-firstnote.diff
@@ -1,0 +1,87 @@
+--- templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
++++ development/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-full-firstnote.csl
+@@ -2,8 +2,8 @@
+ <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded">
+   <!-- Polyglot; this citation style supports both Norwegian dialects, i.e. bokmål (nb-NO) and nynorsk (nn-NO) -->
+   <info>
+-    <title>Norsk henvisningsstandard for rettsvitenskapelige tekster (Norsk - Bokmål | Norsk - Nynorsk) [template]</title>
+-    <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster</id>
++    <title>Norsk henvisningsstandard for rettsvitenskapelige tekster – fullstendig førstenote (Norsk - Bokmål | Norsk - Nynorsk)</title>
++    <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-full-firstnote</id>
+     <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster" rel="self"/>
+     <link href="http://www.zotero.org/styles/universitetet-i-oslo-rettsvitenskap" rel="template"/>
+     <link href="https://www.uib.no/sites/w3.uib.no/files/attachments/veiledning_for_henvisning_i_juridiske_tekster.pdf" rel="documentation"/>
+@@ -18,7 +18,7 @@
+     </contributor>
+     <category citation-format="note"/>
+     <category field="law"/>
+-    <summary>Norwegian legal citation style based on "Veiledning for henvisninger i juridiske tekster" (February 2019).</summary>
++    <summary>Norwegian legal citation style based on "Veiledning for henvisninger i juridiske tekster" (February 2019). Variant with full note on first citation, subsequent notes in short form (bibliography optional).</summary>
+     <updated>2026-03-10T22:12:00+00:00</updated>
+     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+   </info>
+@@ -517,10 +517,61 @@
+     <layout delimiter="; ">
+       <group delimiter=" ">
+         <choose>
+-          <if type="book thesis chapter entry-encyclopedia paper-conference article-journal article-newspaper article-magazine post-weblog" match="any">
+-            <text macro="author-short"/>
+-            <text macro="issued"/>
++          <if type="book">
++            <choose>
++              <if position="first">
++                <text macro="default-bib"/>
++              </if>
++              <else>
++                <text macro="author-short"/>
++                <text macro="issued"/>
++              </else>
++            </choose>
+           </if>
++          <else-if type="thesis">
++            <choose>
++              <if position="first">
++                <text macro="thesis-bib"/>
++              </if>
++              <else>
++                <text macro="author-short"/>
++                <text macro="issued"/>
++              </else>
++            </choose>
++          </else-if>
++          <else-if type="chapter entry-encyclopedia paper-conference" match="any">
++            <choose>
++              <if position="first">
++                <text macro="chapter-encyclopediaentry-conferencepaper-bib"/>
++              </if>
++              <else>
++                <text macro="author-short"/>
++                <text macro="issued"/>
++              </else>
++            </choose>
++          </else-if>
++          <else-if type="article-journal">
++            <choose>
++              <if position="first">
++                <text macro="article-journal-bib"/>
++              </if>
++              <else>
++                <text macro="author-short"/>
++                <text macro="issued"/>
++              </else>
++            </choose>
++          </else-if>
++          <else-if type="article-newspaper article-magazine post-weblog" match="any">
++            <choose>
++              <if position="first">
++                <text macro="article-newspaper-magazine-weblog-bib"/>
++              </if>
++              <else>
++                <text macro="author-short"/>
++                <text macro="issued"/>
++              </else>
++            </choose>
++          </else-if>
+           <else-if type="legislation regulation">
+             <choose>
+               <if position="first">

--- a/diffs/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-full-firstnote.diff
+++ b/diffs/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-full-firstnote.diff
@@ -1,16 +1,18 @@
 --- templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
 +++ development/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-full-firstnote.csl
-@@ -2,8 +2,8 @@
+@@ -2,9 +2,9 @@
  <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded">
    <!-- Polyglot; this citation style supports both Norwegian dialects, i.e. bokmål (nb-NO) and nynorsk (nn-NO) -->
    <info>
 -    <title>Norsk henvisningsstandard for rettsvitenskapelige tekster (Norsk - Bokmål | Norsk - Nynorsk) [template]</title>
 -    <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster</id>
+-    <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster" rel="self"/>
 +    <title>Norsk henvisningsstandard for rettsvitenskapelige tekster – fullstendig førstenote (Norsk - Bokmål | Norsk - Nynorsk)</title>
 +    <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-full-firstnote</id>
-     <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster" rel="self"/>
++    <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-full-firstnote" rel="self"/>
      <link href="http://www.zotero.org/styles/universitetet-i-oslo-rettsvitenskap" rel="template"/>
      <link href="https://www.uib.no/sites/w3.uib.no/files/attachments/veiledning_for_henvisning_i_juridiske_tekster.pdf" rel="documentation"/>
+     <link href="https://obykanalen.no/zotero/" rel="documentation"/>
 @@ -18,7 +18,7 @@
      </contributor>
      <category citation-format="note"/>

--- a/diffs/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.diff
+++ b/diffs/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.diff
@@ -1,0 +1,20 @@
+--- templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
++++ development/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+@@ -2,7 +2,7 @@
+ <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded">
+   <!-- Polyglot; this citation style supports both Norwegian dialects, i.e. bokmål (nb-NO) and nynorsk (nn-NO) -->
+   <info>
+-    <title>Norsk henvisningsstandard for rettsvitenskapelige tekster (Norsk - Bokmål | Norsk - Nynorsk) [template]</title>
++    <title>Norsk henvisningsstandard for rettsvitenskapelige tekster – kortnoter (Norsk - Bokmål | Norsk - Nynorsk)</title>
+     <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster</id>
+     <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster" rel="self"/>
+     <link href="http://www.zotero.org/styles/universitetet-i-oslo-rettsvitenskap" rel="template"/>
+@@ -18,7 +18,7 @@
+     </contributor>
+     <category citation-format="note"/>
+     <category field="law"/>
+-    <summary>Norwegian legal citation style based on "Veiledning for henvisninger i juridiske tekster" (February 2019).</summary>
++    <summary>Norwegian legal citation style based on "Veiledning for henvisninger i juridiske tekster" (February 2019). Variant with short form notes (bibliography required).</summary>
+     <updated>2026-03-10T22:12:00+00:00</updated>
+     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+   </info>

--- a/src/style_variant_builder/build.py
+++ b/src/style_variant_builder/build.py
@@ -150,6 +150,11 @@ class CSLBuilder:
                 shutil.copy(template_path, tmp_file.name)
                 tmp_file_path = Path(tmp_file.name)
 
+            # Normalize to LF so patch works regardless of platform line endings
+            tmp_file_path.write_bytes(
+                tmp_file_path.read_bytes().replace(b"\r\n", b"\n")
+            )
+
             patched_file = tmp_file_path
             result = subprocess.run(
                 ["patch", "-N", str(patched_file), str(diff_path)],

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -424,7 +424,7 @@
         <text macro="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=" " prefix=", ">
+        <group prefix=", ">
           <text variable="URL"/>
           <text macro="accessed-date"/>
         </group>

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -160,7 +160,7 @@
           <date-part name="year"/>
         </date>
       </if>
-      <else-if type="personal_communication" match="all">
+      <else-if type="personal_communication">
         <date variable="accessed" prefix="(" suffix=")">
           <date-part name="year"/>
         </date>
@@ -608,7 +608,7 @@
         <else-if type="article-newspaper article-magazine post-weblog" match="any">
           <text macro="article-newspaper-magazine-weblog-bib" suffix="."/>
         </else-if>
-        <else-if type="thesis" match="any">
+        <else-if type="thesis">
           <text macro="thesis-bib" suffix="."/>
         </else-if>
         <else-if type="chapter entry-encyclopedia paper-conference" match="any">

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -229,7 +229,7 @@
   </macro>
   <macro name="volume">
     <choose>
-      <if variable="volume" match="any">
+      <if variable="volume">
         <group delimiter=" ">
           <label variable="volume"/>
           <text variable="volume"/>
@@ -255,7 +255,7 @@
   </macro>
   <macro name="nor-case">
     <choose>
-      <if variable="container-title" match="any">
+      <if variable="container-title">
         <group delimiter=" ">
           <text variable="container-title"/>
           <text variable="volume"/>
@@ -266,7 +266,7 @@
           <text prefix="(" suffix=")" font-style="italic" variable="title-short"/>
         </group>
       </if>
-      <else-if variable="number" match="any">
+      <else-if variable="number">
         <group delimiter=" ">
           <text variable="number"/>
           <text prefix="(" suffix=")" font-style="italic" variable="title-short"/>
@@ -300,7 +300,7 @@
       <text variable="container-title"/>
       <choose>
         <!-- Preparatory works and other documents from the Storting (parliament) have volume number -->
-        <if variable="volume" match="any">
+        <if variable="volume">
           <text variable="number"/>
           <text variable="volume" prefix="(" suffix=")"/>
         </if>
@@ -328,7 +328,7 @@
       <group delimiter=" ">
         <choose>
           <!-- For journals with continuous issue numbers, with page numbers restarting for each issue (MarIus etc.) -->
-          <if variable="number" match="any">
+          <if variable="number">
             <label variable="number" form="short"/>
             <text variable="number"/>
           </if>
@@ -348,22 +348,22 @@
       <text macro="title"/>
       <text font-style="italic" variable="container-title"/>
       <choose>
-        <if variable="issued" match="any">
+        <if variable="issued">
           <text macro="issued-full-date"/>
         </if>
       </choose>
       <group delimiter=" ">
         <choose>
-          <if variable="page" match="any">
+          <if variable="page">
             <label variable="page" form="short"/>
             <text variable="page"/>
           </if>
         </choose>
         <choose>
-          <if variable="DOI" match="any">
+          <if variable="DOI">
             <text macro="DOI"/>
           </if>
-          <else-if variable="URL" match="any">
+          <else-if variable="URL">
             <text variable="URL"/>
             <text macro="accessed-date"/>
           </else-if>
@@ -376,7 +376,7 @@
       <text macro="author-full"/>
       <text macro="title"/>
       <choose>
-        <if variable="URL" match="any">
+        <if variable="URL">
           <group>
             <text variable="URL"/>
             <text macro="accessed-date"/>
@@ -413,10 +413,10 @@
       </group>
     </group>
     <choose>
-      <if variable="DOI" match="any">
+      <if variable="DOI">
         <text macro="DOI"/>
       </if>
-      <else-if variable="URL" match="any">
+      <else-if variable="URL">
         <group delimiter=" " prefix=", ">
           <text variable="URL"/>
           <text macro="accessed-date"/>
@@ -463,7 +463,7 @@
       </group>
     </group>
   </macro>
-   <macro name="locator">
+  <macro name="locator">
     <choose>
       <if type="legislation regulation" match="any">
         <choose>
@@ -526,7 +526,7 @@
                   <text macro="title-short" prefix="(" suffix=")"/>
                 </group>
               </if>
-              <else-if variable="title-short" match="any">
+              <else-if variable="title-short">
                 <text macro="title-short"/>
               </else-if>
               <else>
@@ -551,7 +551,7 @@
                   <text macro="treaty-details"/>
                 </group>
               </if>
-              <else-if variable="title-short" match="any">
+              <else-if variable="title-short">
                 <text macro="title-short"/>
               </else-if>
               <else>

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -445,7 +445,7 @@
           <!-- Hack (see <locale> for details) -->
           <text term="henceforth"/>
           <names variable="author">
-            <name delimiter-precedes-last="never" name-as-sort-order="first" et-al-min="99" and="text"/>
+            <name delimiter-precedes-last="never" et-al-min="99" and="text"/>
             <et-al term="and others"/>
           </names>
         </group>

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -44,16 +44,16 @@
   </locale>
   <macro name="type-sorting">
     <choose>
-      <if type="webpage regulation legislation bill legal_case treaty" match="none">
+      <if type="webpage legislation regulation bill legal_case treaty" match="none">
         <text value="1"/>
       </if>
       <else-if type="webpage">
         <text value="2"/>
       </else-if>
-      <else-if type="regulation">
+      <else-if type="legislation">
         <text value="3"/>
       </else-if>
-      <else-if type="legislation">
+      <else-if type="regulation">
         <text value="4"/>
       </else-if>
       <else-if type="bill">

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -1,0 +1,644 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded">
+  <!-- Polyglot; this citation style supports both Norwegian dialects, i.e. bokmål (nb-NO) and nynorsk (nn-NO) -->
+  <info>
+    <title>Norsk henvisningsstandard for rettsvitenskapelige tekster (Norsk - Bokmål | Norsk - Nynorsk) [template]</title>
+    <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster</id>
+    <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster" rel="self"/>
+    <link href="http://www.zotero.org/styles/universitetet-i-oslo-rettsvitenskap" rel="template"/>
+    <link href="https://www.uib.no/sites/w3.uib.no/files/attachments/veiledning_for_henvisning_i_juridiske_tekster.pdf" rel="documentation"/>
+    <link href="https://obykanalen.no/zotero/" rel="documentation"/>
+    <author>
+      <name>Stian Øby Johansen</name>
+      <email>s.o.johansen@jus.uio.no</email>
+    </author>
+    <contributor>
+      <name>Hans Gunnar Slokvik Lian</name>
+      <email>h.g.s.lian@ub.uio.no</email>
+    </contributor>
+    <category citation-format="note"/>
+    <category field="law"/>
+    <summary>Norwegian legal citation style based on "Veiledning for henvisninger i juridiske tekster" (February 2019).</summary>
+    <updated>2026-03-10T22:12:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="nb">
+    <terms>
+      <term name="and others">et al.</term>
+      <term name="accessed">lest</term>
+      <!-- Hack: utilize terms not used by the style for treaty-specific terms -->
+      <term name="in press">i kraft</term>
+      <!-- Hack: utilize terms not used by the style for treaty-specific terms -->
+      <term name="henceforth">traktat mellom</term>
+    </terms>
+  </locale>
+  <locale xml:lang="nn">
+    <terms>
+      <term name="and others">et al.</term>
+      <term name="accessed">lest</term>
+      <!-- Hack: utilize terms not used by the style for treaty-specific terms -->
+      <term name="in press">i kraft</term>
+      <!-- Hack: utilize terms not used by the style for treaty-specific terms -->
+      <term name="henceforth">traktat mellom</term>
+    </terms>
+  </locale>
+  <macro name="type-sorting">
+    <choose>
+      <if type="webpage regulation legislation bill legal_case treaty" match="none">
+        <text value="1"/>
+      </if>
+      <else-if type="webpage">
+        <text value="2"/>
+      </else-if>
+      <else-if type="legislation">
+        <text value="3"/>
+      </else-if>
+      <else-if type="regulation">
+        <text value="4"/>
+      </else-if>
+      <else-if type="bill">
+        <text value="5"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text value="6"/>
+      </else-if>
+      <else-if type="treaty">
+        <text value="7"/>
+      </else-if>
+      <else>
+        <text value="8"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="legal_case-authority">
+    <choose>
+      <if type="legal_case">
+        <text variable="authority"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="date-sorting">
+    <choose>
+      <if type="bill legislation regulation legal_case" match="any">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month" form="numeric"/>
+          <date-part name="day" form="numeric-leading-zeros"/>
+        </date>
+      </if>
+      <else-if type="treaty">
+        <date variable="available-date">
+          <date-part name="year"/>
+          <date-part name="month" form="numeric"/>
+          <date-part name="day" form="numeric-leading-zeros"/>
+        </date>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
+      <et-al term="and others"/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-full">
+    <names variable="author">
+      <name delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
+      <et-al term="and others"/>
+      <substitute>
+        <text macro="editor-invert"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name delimiter-precedes-last="never" and="text"/>
+      <et-al term="and others"/>
+      <label prefix=" (" suffix=")" form="short"/>
+    </names>
+  </macro>
+  <macro name="editor-invert">
+    <names variable="editor">
+      <name delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
+      <et-al term="and others"/>
+      <label prefix=" (" suffix=")" form="short"/>
+    </names>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if type="article-journal chapter" match="any">
+        <text quotes="true" variable="title"/>
+      </if>
+      <else-if type="bill legislation regulation treaty" match="any">
+        <text variable="title-short"/>
+      </else-if>
+      <else>
+        <text font-style="italic" variable="title-short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="chapter entry-encyclopedia article-journal article-newspaper article-magazine post-weblog" match="any">
+        <text quotes="true" variable="title"/>
+      </if>
+      <else-if type="bill treaty" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="personal_communication" match="none">
+        <date prefix="(" suffix=")" variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else-if type="personal_communication" match="all">
+        <date variable="accessed" prefix="(" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+      <else>
+        <text term="no date" prefix="(" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-full-date">
+    <date variable="issued" delimiter=" ">
+      <date-part name="day" form="numeric" suffix="."/>
+      <date-part name="month" form="long"/>
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="available-full-date">
+    <date variable="available-date" delimiter=" ">
+      <date-part name="day" form="numeric" suffix="."/>
+      <date-part name="month" form="long"/>
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="accessed-date">
+    <group delimiter=" " prefix=" (" suffix=")">
+      <text term="accessed"/>
+      <date variable="accessed" delimiter=" ">
+        <date-part name="day" form="numeric" suffix="."/>
+        <date-part name="month" form="long"/>
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="issued-no-parenthesis">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="retrieved-from">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=" " prefix=" (" suffix=")">
+          <text term="cited"/>
+          <text term="from"/>
+          <text variable="archive" text-case="capitalize-first"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition-short">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume">
+    <choose>
+      <if variable="volume" match="any">
+        <group delimiter=" ">
+          <label variable="volume"/>
+          <text variable="volume"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="DOI">
+    <text variable="DOI" prefix=". DOI: https://doi.org/"/>
+  </macro>
+  <macro name="default-bib">
+    <group delimiter=", ">
+      <text macro="author-full"/>
+      <text macro="title"/>
+      <text macro="volume"/>
+      <text macro="edition-short"/>
+      <group delimiter=" ">
+        <text variable="publisher"/>
+        <text macro="issued-no-parenthesis"/>
+      </group>
+    </group>
+    <text macro="DOI"/>
+  </macro>
+  <macro name="nor-case">
+    <choose>
+      <if variable="container-title" match="any">
+        <group delimiter=" ">
+          <text variable="container-title"/>
+          <text variable="volume"/>
+          <group delimiter=" ">
+            <label variable="page" form="short"/>
+            <text variable="page"/>
+          </group>
+          <text prefix="(" suffix=")" font-style="italic" variable="title-short"/>
+        </group>
+      </if>
+      <else-if variable="number" match="any">
+        <group delimiter=" ">
+          <text variable="number"/>
+          <text prefix="(" suffix=")" font-style="italic" variable="title-short"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter=" ">
+          <text macro="author-full" suffix="s dom"/>
+          <!-- Hack: using term "by" for "av", due to CSL lacking an "of" term -->
+          <text term="by"/>
+          <text macro="issued-full-date"/>
+        </group>
+        <text prefix=" (" suffix=")" font-style="italic" variable="title-short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="nor-legislation">
+    <group delimiter=" ">
+      <text variable="container-title"/>
+      <text macro="issued-full-date"/>
+      <group delimiter=" ">
+        <label variable="number" form="short"/>
+        <text variable="volume"/>
+      </group>
+      <text variable="title"/>
+    </group>
+  </macro>
+  <macro name="nor-prepworks">
+    <!-- bill is used for preparatory works (NOU/prp./innst.) -->
+    <group delimiter=" ">
+      <text variable="container-title"/>
+      <choose>
+        <!-- Preparatory works and other documents from the Storting (parliament) have volume number -->
+        <if variable="volume" match="any">
+          <text variable="number"/>
+          <text variable="volume" prefix="(" suffix=")"/>
+        </if>
+        <!-- NOU formatting for preparatory works without volume number -->
+        <else>
+          <text macro="issued-no-parenthesis" suffix=":"/>
+          <text variable="number"/>
+        </else>
+      </choose>
+      <choose>
+        <if position="subsequent" match="none">
+          <text macro="title"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="article-journal-bib">
+    <group delimiter=", ">
+      <text macro="author-full"/>
+      <group delimiter=" ">
+        <text macro="title"/>
+        <text variable="container-title" font-style="italic"/>
+        <text macro="issued-no-parenthesis"/>
+      </group>
+      <group delimiter=" ">
+        <choose>
+          <!-- For journals with continuous issue numbers, with page numbers restarting for each issue (MarIus etc.) -->
+          <if variable="number" match="any">
+            <label variable="number" form="short"/>
+            <text variable="number"/>
+          </if>
+        </choose>
+      </group>
+      <group delimiter=" ">
+        <label variable="page" form="short"/>
+        <text variable="page"/>
+      </group>
+    </group>
+    <text macro="DOI"/>
+    <text macro="retrieved-from"/>
+  </macro>
+  <macro name="article-newspaper-magazine-weblog-bib">
+    <group delimiter=", ">
+      <text macro="author-full"/>
+      <text macro="title"/>
+      <text font-style="italic" variable="container-title"/>
+      <choose>
+        <if variable="issued" match="any">
+          <text macro="issued-full-date"/>
+        </if>
+      </choose>
+      <group delimiter=" ">
+        <choose>
+          <if variable="page" match="any">
+            <label variable="page" form="short"/>
+            <text variable="page"/>
+          </if>
+        </choose>
+        <choose>
+          <if variable="DOI" match="any">
+            <text macro="DOI"/>
+          </if>
+          <else-if variable="URL" match="any">
+            <text variable="URL"/>
+            <text macro="accessed-date"/>
+          </else-if>
+        </choose>
+      </group>
+    </group>
+  </macro>
+  <macro name="webpage-post-bib">
+    <group delimiter=", ">
+      <text macro="author-full"/>
+      <text macro="title"/>
+      <choose>
+        <if variable="URL" match="any">
+          <group>
+            <text variable="URL"/>
+            <text macro="accessed-date"/>
+          </group>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="thesis-bib">
+    <group delimiter=", ">
+      <text macro="author-full"/>
+      <text macro="title"/>
+      <text macro="volume"/>
+      <text macro="edition-short"/>
+      <text variable="publisher"/>
+      <text macro="issued-full-date"/>
+    </group>
+    <text macro="DOI"/>
+  </macro>
+  <macro name="chapter-encyclopediaentry-conferencepaper-bib">
+    <group delimiter=", ">
+      <text macro="author-full"/>
+      <text macro="title"/>
+      <group delimiter=" ">
+        <text term="in"/>
+        <text variable="container-title" font-style="italic"/>
+      </group>
+      <text macro="editor"/>
+      <text macro="volume"/>
+      <text macro="edition-short"/>
+      <group delimiter=" ">
+        <text variable="publisher"/>
+        <text macro="issued-no-parenthesis"/>
+      </group>
+    </group>
+    <choose>
+      <if variable="DOI" match="any">
+        <text macro="DOI"/>
+      </if>
+      <else-if variable="URL" match="any">
+        <group delimiter=" " prefix=", ">
+          <text variable="URL"/>
+          <text macro="accessed-date"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="personal_communication-bib">
+    <group delimiter=" ">
+      <text macro="author-full"/>
+      <text macro="issued"/>
+    </group>
+  </macro>
+  <macro name="treaty-details">
+    <group delimiter=" ">
+      <!-- In the CSL specification, "Date Variables", it is stated under "available-date": "the date a treaty was made available for signing". In (legal) citation of treaties, and in the style in question, date enacted and date in force is used. Date enacted and the date a treaty is opened for signature is usually the same date, thus "available-date" is used for date enacted. -->
+      <text macro="available-full-date"/>
+      <group prefix="(" delimiter=", " suffix=")">
+        <group delimiter=" ">
+          <!-- Hack (see <locale> for details) -->
+          <text term="henceforth"/>
+          <names variable="author">
+            <name delimiter-precedes-last="never" name-as-sort-order="first" et-al-min="99" and="text"/>
+            <et-al term="and others"/>
+          </names>
+        </group>
+        <group delimiter=" ">
+          <!-- Hack (see <locale> for details) -->
+          <text term="in press"/>
+          <!-- "issued" is mapped to "Date Enacted" in Zotero, but nevertheless used for the "in force" date in this style due to the above-mentioned mention of treaty in the CSL specification for "available-date". -->
+          <text macro="issued-full-date"/>
+        </group>
+      </group>
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text variable="volume"/>
+          <text variable="container-title"/>
+          <text variable="page"/>
+        </group>
+        <group>
+          <!-- "number" = "Public Law Number" in Zotero -->
+          <text variable="number"/>
+        </group>
+      </group>
+    </group>
+  </macro>
+   <macro name="locator">
+    <choose>
+      <if type="legislation regulation" match="any">
+        <choose>
+          <if locator="section paragraph" match="any">
+            <group delimiter="&#160;">
+              <label variable="section" form="symbol"/>
+              <text variable="locator"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter="&#160;">
+              <label variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if locator="paragraph article-locator" match="any">
+            <group delimiter=" ">
+              <label variable="locator" form="long"/>
+              <text variable="locator"/>
+            </group>
+          </if>
+          <else-if locator="page">
+            <group delimiter="&#160;">
+              <label variable="locator" form="long"/>
+              <text variable="locator"/>
+            </group>
+          </else-if>
+          <else>
+            <group delimiter=" ">
+              <label variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <citation disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="true" et-al-min="4" et-al-use-first="1">
+    <sort>
+      <key macro="author-short"/>
+      <key macro="title-short"/>
+      <key macro="issued"/>
+    </sort>
+    <layout delimiter="; ">
+      <group delimiter=" ">
+        <choose>
+          <if type="book thesis chapter entry-encyclopedia paper-conference article-journal article-newspaper article-magazine post-weblog" match="any">
+            <text macro="author-short"/>
+            <text macro="issued"/>
+          </if>
+          <else-if type="legislation regulation">
+            <choose>
+              <if position="first">
+                <group delimiter=" ">
+                  <text macro="nor-legislation"/>
+                  <text macro="title-short" prefix="(" suffix=")"/>
+                </group>
+              </if>
+              <else-if variable="title-short" match="any">
+                <text macro="title-short"/>
+              </else-if>
+              <else>
+                <group delimiter=" ">
+                  <text variable="container-title"/>
+                  <text variable="title"/>
+                </group>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="bill">
+            <text macro="nor-prepworks"/>
+          </else-if>
+          <else-if type="treaty">
+            <choose>
+              <if position="first">
+                <group delimiter=", ">
+                  <group delimiter=" ">
+                    <text macro="title"/>
+                    <text macro="title-short" prefix="(" suffix=")"/>
+                  </group>
+                  <text macro="treaty-details"/>
+                </group>
+              </if>
+              <else-if variable="title-short" match="any">
+                <text macro="title-short"/>
+              </else-if>
+              <else>
+                <text variable="title"/>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="legal_case">
+            <text macro="nor-case"/>
+          </else-if>
+          <else-if type="webpage post" match="any">
+            <text macro="webpage-post-bib"/>
+          </else-if>
+          <else-if type="personal_communication">
+            <text macro="personal_communication-bib"/>
+          </else-if>
+          <else-if type="report">
+            <choose>
+              <if variable="author" match="none">
+                <text variable="title"/>
+                <text macro="issued"/>
+              </if>
+              <else>
+                <text macro="author-short"/>
+                <text macro="issued"/>
+              </else>
+            </choose>
+          </else-if>
+          <else>
+            <text variable="title"/>
+          </else>
+        </choose>
+        <text macro="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="1">
+    <sort>
+      <key macro="type-sorting"/>
+      <key macro="legal_case-authority"/>
+      <key macro="date-sorting"/>
+      <key macro="author-full"/>
+      <key variable="issued"/>
+      <key variable="title"/>
+    </sort>
+    <layout>
+      <choose>
+        <if type="article-journal">
+          <text macro="article-journal-bib" suffix="."/>
+        </if>
+        <else-if type="article-newspaper article-magazine post-weblog" match="any">
+          <text macro="article-newspaper-magazine-weblog-bib" suffix="."/>
+        </else-if>
+        <else-if type="thesis" match="any">
+          <text macro="thesis-bib" suffix="."/>
+        </else-if>
+        <else-if type="chapter entry-encyclopedia paper-conference" match="any">
+          <text macro="chapter-encyclopediaentry-conferencepaper-bib" suffix="."/>
+        </else-if>
+        <else-if type="legislation regulation" match="any">
+          <text macro="nor-legislation" suffix="."/>
+        </else-if>
+        <else-if type="bill">
+          <text macro="nor-prepworks" suffix="."/>
+        </else-if>
+        <else-if type="treaty">
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text macro="treaty-details" suffix="."/>
+          </group>
+        </else-if>
+        <else-if type="legal_case">
+          <text macro="nor-case" suffix="."/>
+        </else-if>
+        <else-if type="webpage post" match="any">
+          <text macro="webpage-post-bib" suffix="."/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="personal_communication-bib" suffix="."/>
+        </else-if>
+        <else>
+          <text macro="default-bib" suffix="."/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -338,7 +338,6 @@
           </group>
         </if>
       </choose>
-      </group>
       <group delimiter=" ">
         <label variable="page" form="short"/>
         <text variable="page"/>

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -97,7 +97,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
+      <name form="short" delimiter-precedes-last="never" and="text"/>
       <et-al term="and others"/>
       <substitute>
         <names variable="editor"/>

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -352,24 +352,26 @@
           <text macro="issued-full-date"/>
         </if>
       </choose>
-      <group delimiter=" ">
-        <choose>
-          <if variable="page">
+      <choose>
+        <if variable="page">
+          <group delimiter=" ">
             <label variable="page" form="short"/>
             <text variable="page"/>
-          </if>
-        </choose>
-        <choose>
-          <if variable="DOI">
-            <text macro="DOI"/>
-          </if>
-          <else-if variable="URL">
-            <text variable="URL"/>
-            <text macro="accessed-date"/>
-          </else-if>
-        </choose>
-      </group>
+          </group>
+        </if>
+      </choose>
     </group>
+    <choose>
+      <if variable="DOI">
+        <text macro="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <group prefix=", ">
+          <text variable="URL"/>
+          <text macro="accessed-date"/>
+        </group>
+      </else-if>
+    </choose>
   </macro>
   <macro name="webpage-post-bib">
     <group delimiter=", ">

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -155,13 +155,13 @@
   </macro>
   <macro name="issued">
     <choose>
-      <if type="personal_communication" match="none">
-        <date prefix="(" suffix=")" variable="issued">
+      <if type="personal_communication" variable="accessed">
+        <date variable="accessed" prefix="(" suffix=")">
           <date-part name="year"/>
         </date>
       </if>
-      <else-if type="personal_communication">
-        <date variable="accessed" prefix="(" suffix=")">
+      <else-if variable="issued">
+        <date prefix="(" suffix=")" variable="issued">
           <date-part name="year"/>
         </date>
       </else-if>

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -50,10 +50,10 @@
       <else-if type="webpage">
         <text value="2"/>
       </else-if>
-      <else-if type="legislation">
+      <else-if type="regulation">
         <text value="3"/>
       </else-if>
-      <else-if type="regulation">
+      <else-if type="legisla<tion">
         <text value="4"/>
       </else-if>
       <else-if type="bill">
@@ -65,9 +65,6 @@
       <else-if type="treaty">
         <text value="7"/>
       </else-if>
-      <else>
-        <text value="8"/>
-      </else>
     </choose>
   </macro>
   <macro name="legal_case-authority">

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -53,7 +53,7 @@
       <else-if type="regulation">
         <text value="3"/>
       </else-if>
-      <else-if type="legisla<tion">
+      <else-if type="legislation">
         <text value="4"/>
       </else-if>
       <else-if type="bill">

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -621,9 +621,9 @@
           <text macro="nor-prepworks" suffix="."/>
         </else-if>
         <else-if type="treaty">
-          <group delimiter=", ">
+          <group delimiter=", " suffix=".">
             <text macro="title"/>
-            <text macro="treaty-details" suffix="."/>
+            <text macro="treaty-details"/>
           </group>
         </else-if>
         <else-if type="legal_case">

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -329,14 +329,15 @@
         <text variable="container-title" font-style="italic"/>
         <text macro="issued-no-parenthesis"/>
       </group>
-      <group delimiter=" ">
-        <choose>
-          <!-- For journals with continuous issue numbers, with page numbers restarting for each issue (MarIus etc.) -->
-          <if variable="number">
+      <choose>
+        <!-- For journals with continuous issue numbers, with page numbers restarting for each issue (MarIus etc.) -->
+        <if variable="number">
+          <group delimiter=" ">
             <label variable="number" form="short"/>
             <text variable="number"/>
-          </if>
-        </choose>
+          </group>
+        </if>
+      </choose>
       </group>
       <group delimiter=" ">
         <label variable="page" form="short"/>

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="https://raw.githubusercontent.com/citation-style-language/schema/refs/heads/master/schemas/styles/csl-repository.rnc"
+  type="application/relax-ng-compact-syntax" schematypens="http://relaxng.org/ns/compatibility/annotations/1.0"?>
+<?xml-model href="https://raw.githubusercontent.com/citation-style-language/schema/refs/heads/master/schemas/styles/csl-repository.rnc"
+  type="application/relax-ng-compact-syntax" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded">
   <!-- Polyglot; this citation style supports both Norwegian dialects, i.e. bokmål (nb-NO) and nynorsk (nn-NO) -->
   <info>

--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -512,7 +512,7 @@
     <sort>
       <key macro="author-short"/>
       <key macro="title-short"/>
-      <key macro="issued"/>
+      <key macro="issued-no-parenthesis"/>
     </sort>
     <layout delimiter="; ">
       <group delimiter=" ">


### PR DESCRIPTION
Adds a template and diffs for two variants of the Norwegian legal citation style "Norsk henvisningsstandard for rettsvitenskapelige tekster".

PS: thanks for this excellent tool. I hope that it is OK to add new styles to the repo, so that others may contribute to the template and diffs too. If you prefer a different way of doing things for those of us wanting to use the style variant builder to publish style variants, please advise.