### PR TITLE
fix wrong locator page form (long->short)

### DIFF
--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -497,7 +497,7 @@
           </if>
           <else-if locator="page">
             <group delimiter="&#160;">
-              <label variable="locator" form="long"/>
+              <label variable="locator" form="short"/>
               <text variable="locator"/>
             </group>
           </else-if>


### PR DESCRIPTION
Fixed a minor error that I introduced while refactoring the locator macro (page locator should be short, not long).