### PR TITLE
Add volume number for monographs without editor

### DIFF
--- a/templates/modern-language-association-template.csl
+++ b/templates/modern-language-association-template.csl
@@ -747,6 +747,9 @@
             <if match="any" variable="container-author contributor director editor editor-translator illustrator interviewer translator">
               <text macro="label-volume"/>
             </if>
+            <else>
+              <text macro="label-volume-capitalized"/>
+            </else>
           </choose>
         </else-if>
         <else>


### PR DESCRIPTION
The current conditionals don't kick in for books with no secondary creators, we need to repeat the call to the capitalized volume macro

cc @adunning if you have a minute to look at this? Though I'm pretty sure I'm right about this.