### PR TITLE
norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl: remove citation sort macro

### DIFF
--- a/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
+++ b/templates/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster-template.csl
@@ -512,11 +512,6 @@
     </choose>
   </macro>
   <citation disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="true" et-al-min="4" et-al-use-first="1">
-    <sort>
-      <key macro="author-short"/>
-      <key macro="title-short"/>
-      <key macro="issued-no-parenthesis"/>
-    </sort>
     <layout delimiter="; ">
       <group delimiter=" ">
         <choose>


### PR DESCRIPTION
Remove citation sort sort macro, which:
- causes issues when switching from other citation formats.
- is not needed (style guide does not provide a default sort order)
- is generally not useful for legal citation (ordering of references in legal footnotes tend to imply importance etc, which cannot be captured by a general/default sort order)